### PR TITLE
tabline now only shows the filename instead of the whole path

### DIFF
--- a/.vim/plugin/plugins.vim
+++ b/.vim/plugin/plugins.vim
@@ -173,6 +173,7 @@ endif
 
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#buffer_idx_mode = 1
+let g:airline#extensions#tabline#formatter = 'unique_tail'
 nmap <C-w>1 <Plug>AirlineSelectTab1
 nmap <C-w>2 <Plug>AirlineSelectTab2
 nmap <C-w>3 <Plug>AirlineSelectTab3


### PR DESCRIPTION
Shortens the path of tabline to filename only