### PR TITLE
Added missing list initialization

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -226,6 +226,7 @@ def FlagsForCompilationDatabase(root, filename):
 
 
 def FlagsForFile(filename):
+    final_flags = []
     root = os.path.realpath(filename)
     compilation_db_flags = FlagsForCompilationDatabase(root, filename)
     if compilation_db_flags:


### PR DESCRIPTION
This resulted in an error, if no compilation_db_flags were found and the file is no source file. 
``` final_flags = final_flags + include_flags ``` complained that final_flags was used before it was initialized.
